### PR TITLE
Port LaunchDarkly migration script over

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1605 @@
+{
+  "name": "migrations",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "migrations",
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "nullthrows": "^1.1.1",
+        "p-throttle": "^7.0.0"
+      },
+      "devDependencies": {
+        "@types/minimist": "^1.2.5",
+        "@types/node": "^24.0.13",
+        "prettier": "^3.6.2",
+        "prettier-plugin-import-sort": "^0.0.7",
+        "tsx": "^4.20.3",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
+      "integrity": "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.6.tgz",
+      "integrity": "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz",
+      "integrity": "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.6.tgz",
+      "integrity": "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz",
+      "integrity": "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz",
+      "integrity": "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz",
+      "integrity": "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz",
+      "integrity": "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz",
+      "integrity": "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz",
+      "integrity": "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz",
+      "integrity": "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz",
+      "integrity": "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz",
+      "integrity": "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz",
+      "integrity": "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz",
+      "integrity": "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz",
+      "integrity": "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz",
+      "integrity": "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz",
+      "integrity": "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz",
+      "integrity": "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz",
+      "integrity": "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz",
+      "integrity": "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
+      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caller-callsite": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001727",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.183",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.183.tgz",
+      "integrity": "sha512-vCrDBYjQCAEefWGjlK3EpoSKfKbT10pR4XXPdn65q7snuNOZnthoVpBfZPykmDapOKfoD+MMIPG8ZjKyyc9oHA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
+      "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.6",
+        "@esbuild/android-arm": "0.25.6",
+        "@esbuild/android-arm64": "0.25.6",
+        "@esbuild/android-x64": "0.25.6",
+        "@esbuild/darwin-arm64": "0.25.6",
+        "@esbuild/darwin-x64": "0.25.6",
+        "@esbuild/freebsd-arm64": "0.25.6",
+        "@esbuild/freebsd-x64": "0.25.6",
+        "@esbuild/linux-arm": "0.25.6",
+        "@esbuild/linux-arm64": "0.25.6",
+        "@esbuild/linux-ia32": "0.25.6",
+        "@esbuild/linux-loong64": "0.25.6",
+        "@esbuild/linux-mips64el": "0.25.6",
+        "@esbuild/linux-ppc64": "0.25.6",
+        "@esbuild/linux-riscv64": "0.25.6",
+        "@esbuild/linux-s390x": "0.25.6",
+        "@esbuild/linux-x64": "0.25.6",
+        "@esbuild/netbsd-arm64": "0.25.6",
+        "@esbuild/netbsd-x64": "0.25.6",
+        "@esbuild/openbsd-arm64": "0.25.6",
+        "@esbuild/openbsd-x64": "0.25.6",
+        "@esbuild/openharmony-arm64": "0.25.6",
+        "@esbuild/sunos-x64": "0.25.6",
+        "@esbuild/win32-arm64": "0.25.6",
+        "@esbuild/win32-ia32": "0.25.6",
+        "@esbuild/win32-x64": "0.25.6"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/find-line-column": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/find-line-column/-/find-line-column-0.5.2.tgz",
+      "integrity": "sha512-eNhNkDt5RbxY4X++JwyDURP62FYhV1bh9LF4dfOiwpVCTk5vvfEANhnui5ypUEELGR02QZSrWFtaTgd4ulW5tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-sort": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/import-sort/-/import-sort-6.0.0.tgz",
+      "integrity": "sha512-XUwSQMGAGmcW/wfshFE0gXgb1NPF6ibbQD6wDr3KRDykZf/lZj0jf58Bwa02xNb8EE59oz7etFe9OHnJocUW5Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "detect-newline": "^2.1.0",
+        "import-sort-parser": "^6.0.0",
+        "import-sort-style": "^6.0.0",
+        "is-builtin-module": "^3.0.0",
+        "resolve": "^1.8.1"
+      }
+    },
+    "node_modules/import-sort-config": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/import-sort-config/-/import-sort-config-6.0.0.tgz",
+      "integrity": "sha512-FJpF2F3+30JXqH1rJKeajxoSCHCueai3/0ntDN4y3GJL5pjnLDt/VjCy5FzjH7u0NHnllL/zVEf1wfmsVxJlPQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cosmiconfig": "^5.0.5",
+        "find-root": "^1.0.0",
+        "minimatch": "^3.0.4",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "node_modules/import-sort-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/import-sort-parser/-/import-sort-parser-6.0.0.tgz",
+      "integrity": "sha512-H5L+d6HnqHvThB0GmAA3/43Sv74oCwL0iMk3/ixOv0LRJ69rCyHXeG/+UadMHrD2FefEmgPIWboEPAG7gsQrkA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/import-sort-parser-babylon": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/import-sort-parser-babylon/-/import-sort-parser-babylon-6.0.0.tgz",
+      "integrity": "sha512-NyShTiNhTh4Vy7kJUVe6CuvOaQAzzfSIT72wtp3CzGjz8bHjNj59DCAjncuviicmDOgVAgmLuSh1WMcLYAMWGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@babel/core": "^7.2.2",
+        "@babel/parser": "^7.0.0-beta.54",
+        "@babel/traverse": "^7.0.0-beta.54",
+        "@babel/types": "^7.0.0-beta.54",
+        "find-line-column": "^0.5.2"
+      }
+    },
+    "node_modules/import-sort-parser-typescript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/import-sort-parser-typescript/-/import-sort-parser-typescript-6.0.0.tgz",
+      "integrity": "sha512-pgxnr3I156DonupQriNsgDb2zJN9TxrqCCIN1rwT/6SDO1rkJb+a0fjqshCjlgacTSA92oPAp1eAwmQUeZi3dw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "typescript": "^3.2.4"
+      }
+    },
+    "node_modules/import-sort-parser-typescript/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/import-sort-style": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/import-sort-style/-/import-sort-style-6.0.0.tgz",
+      "integrity": "sha512-z0H5PKs7YoDeKxNYXv2AA1mjjZFY07fjeNCXUdTM3ymJtWeeEoTm8CQkFm2l+KPZoMczIvdwzJpWkkOamBnsPw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "license": "MIT"
+    },
+    "node_modules/p-throttle": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-7.0.0.tgz",
+      "integrity": "sha512-aio0v+S0QVkH1O+9x4dHtD4dgCExACcL+3EtNaGqC01GBudS9ijMuUsmN8OVScyV4OOp0jqdLShZFuSlbL/AsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-import-sort": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-import-sort/-/prettier-plugin-import-sort-0.0.7.tgz",
+      "integrity": "sha512-O0KlUSq+lwvh+UiN3wZDT6wWkf7TNxTVv2/XXE5KqpRNbFJq3nRg2ftzBYFFO8QGpdWIrOB0uCTCtFjIxmVKQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-sort": "^6.0.0",
+        "import-sort-config": "^6.0.0",
+        "import-sort-parser-babylon": "^6.0.0",
+        "import-sort-parser-typescript": "^6.0.0"
+      },
+      "peerDependencies": {
+        "prettier": ">= 2.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "migrations",
+  "version": "0.0.1",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc --build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/statsig-io/migrations.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/statsig-io/migrations/issues"
+  },
+  "homepage": "https://github.com/statsig-io/migrations#readme",
+  "description": "",
+  "devDependencies": {
+    "@types/minimist": "^1.2.5",
+    "@types/node": "^24.0.13",
+    "prettier": "^3.6.2",
+    "prettier-plugin-import-sort": "^0.0.7",
+    "tsx": "^4.20.3",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "minimist": "^1.2.8",
+    "nullthrows": "^1.1.1",
+    "p-throttle": "^7.0.0"
+  }
+}

--- a/src/import.ts
+++ b/src/import.ts
@@ -1,0 +1,80 @@
+import {
+  createStatsigGate,
+  createStatsigTag,
+  deleteStatsigGate,
+  getStatsigGate,
+  getStatsigTag,
+} from './statsig';
+
+import type { Args } from './statsig';
+import { StatsigConfig } from './types';
+
+export async function needToDeleteExistingImportedGates(
+  gateNames: string[],
+  args: Args,
+): Promise<boolean> {
+  for (const gateName of gateNames) {
+    const gate = await getStatsigGate(gateName, args);
+    if (gate) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function deleteExistingImportedGates(
+  gateNames: string[],
+  importTag: string,
+  args: Args,
+): Promise<
+  { ok: true } | { ok: false; existingGatesWithoutImportTag: string[] }
+> {
+  const existingGateNames = [];
+  const existingGatesWithoutImportTag = [];
+  for (const gateName of gateNames) {
+    const gate = await getStatsigGate(gateName, args);
+    if (gate) {
+      existingGateNames.push(gate.name);
+      if (!gate.tags?.includes(importTag)) {
+        existingGatesWithoutImportTag.push(gate.name);
+      }
+    }
+  }
+
+  if (existingGatesWithoutImportTag.length > 0) {
+    return {
+      ok: false,
+      existingGatesWithoutImportTag,
+    };
+  }
+
+  for (const gateName of existingGateNames) {
+    await deleteStatsigGate(gateName, args);
+  }
+
+  return { ok: true };
+}
+
+export async function importConfigs(
+  configs: StatsigConfig[],
+  importTag: string,
+  importTagDescription: string,
+  args: Args,
+): Promise<void> {
+  // Make sure the import tag exists
+  const importTagExists = await getStatsigTag(importTag, args);
+  if (!importTagExists) {
+    await createStatsigTag(importTag, importTagDescription, args);
+  }
+
+  for (const config of configs) {
+    const gate = config.gate;
+    await createStatsigGate(
+      {
+        ...gate,
+        tags: [...(gate.tags || []), importTag],
+      },
+      args,
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,217 @@
+import {
+  deleteExistingImportedGates,
+  importConfigs,
+  needToDeleteExistingImportedGates,
+} from './import';
+import {
+  ensureLaunchDarklySetup,
+  getLaunchDarklyConfigs,
+  launchdarklyApiThrottle,
+} from './launchdarkly';
+import {
+  listStatsigEnvironments,
+  listStatsigUnitIDs,
+  statsigApiThrottle,
+} from './statsig';
+
+import minimist from 'minimist';
+import pThrottle from 'p-throttle';
+import readline from 'readline';
+import { transformErrorToString } from './types';
+
+const LAUNCHDARKLY_IMPORT_TAG = 'Imported from LaunchDarkly';
+const LAUNCHDARKLY_IMPORT_TAG_DESCRIPTION = 'Imported from LaunchDarkly';
+
+enum MigrateFrom {
+  LaunchDarkly = 'launchdarkly',
+}
+
+async function main(): Promise<void> {
+  const argv = minimist(process.argv.slice(2));
+
+  const from = argv.from;
+
+  if (!from) {
+    console.error('Missing required arguments: --from');
+    process.exit(1);
+  }
+
+  const statsigApiKey = process.env.STATSIG_API_KEY;
+  if (!statsigApiKey) {
+    console.error('Missing required environment variable: STATSIG_API_KEY');
+    process.exit(1);
+  }
+  const statsigThrottle = pThrottle(statsigApiThrottle);
+  const statsigArgs = {
+    apiKey: statsigApiKey,
+    throttle: statsigThrottle,
+  };
+
+  if (from === MigrateFrom.LaunchDarkly) {
+    const launchdarklyApiKey = process.env.LAUNCHDARKLY_API_KEY;
+    if (!launchdarklyApiKey) {
+      console.error(
+        'Missing required environment variable: LAUNCHDARKLY_API_KEY',
+      );
+      process.exit(1);
+    }
+    const launchdarklyProjectID = argv['launchdarkly-project-id'];
+    if (!launchdarklyProjectID) {
+      console.error('Missing required argument: --launchdarkly-project-id');
+      process.exit(1);
+    }
+
+    const contextKindToUnitIDMappingArg = argv['context-kind-to-unit-id'];
+    const contextKindToUnitIDMapping = contextKindToUnitIDMappingArg
+      ? Object.fromEntries(
+          (!Array.isArray(contextKindToUnitIDMappingArg)
+            ? [contextKindToUnitIDMappingArg]
+            : contextKindToUnitIDMappingArg
+          ).map((e) => e.split('=')),
+        )
+      : {};
+
+    let environmentNameMappingArg = argv['environment-name-mapping'];
+    const environmentNameMapping = environmentNameMappingArg
+      ? Object.fromEntries(
+          (!Array.isArray(environmentNameMappingArg)
+            ? [environmentNameMappingArg]
+            : environmentNameMappingArg
+          ).map((e) => e.split('=')),
+        )
+      : {};
+
+    const launchdarklyThrottle = pThrottle(launchdarklyApiThrottle);
+    const launchdarklyArgs = {
+      apiKey: launchdarklyApiKey,
+      projectID: launchdarklyProjectID,
+      throttle: launchdarklyThrottle,
+      contextKindToUnitIDMapping,
+      environmentNameMapping,
+    };
+
+    const statsigEnvironments = await listStatsigEnvironments(statsigArgs);
+    const statsigUnitIDs = await listStatsigUnitIDs(statsigArgs);
+
+    const launchDarklySetupResult = await ensureLaunchDarklySetup(
+      statsigEnvironments,
+      statsigUnitIDs,
+      launchdarklyArgs,
+    );
+    if (!launchDarklySetupResult.ok) {
+      if (launchDarklySetupResult.unmappedEnvironments.length > 0) {
+        console.log(
+          `Unmapped environments: ${launchDarklySetupResult.unmappedEnvironments.join(', ')}.\nUse --environment-name-mapping ld-env-name=statsig-env-name to specify a mapping (can specify multiple).`,
+        );
+      }
+      if (launchDarklySetupResult.invalidUnitIDs.length > 0) {
+        console.log(
+          `Invalid unit IDs specified for context kinds: ${launchDarklySetupResult.invalidUnitIDs.join(', ')}.`,
+        );
+      }
+      if (launchDarklySetupResult.contextKindsWithoutUnitIDs.length > 0) {
+        console.log(
+          `Missing unit IDs for context kinds: ${launchDarklySetupResult.contextKindsWithoutUnitIDs.join(', ')}.\nUse --context-kind-to-unit-id context-kind=unit_id to specify a mapping (can specify multiple).`,
+        );
+      }
+      process.exit(1);
+    } else {
+      console.log(
+        'All environments exist in Statsig or have a mapping. All context kinds have mapped unit IDs in Statsig.',
+      );
+    }
+
+    const configTransformResult =
+      await getLaunchDarklyConfigs(launchdarklyArgs);
+
+    console.log('');
+    console.log(
+      `Found a total of ${configTransformResult.totalConfigCount} flags in LaunchDarkly.`,
+    );
+    console.log('');
+    console.log(
+      `${configTransformResult.validConfigs.length} flags can imported:`,
+    );
+    configTransformResult.validConfigs.forEach((config) => {
+      console.log(`- ${config.gate.name}`);
+    });
+    console.log(
+      `\n${Object.keys(configTransformResult.errorsByConfigName).length} flags cannot be imported:`,
+    );
+    Object.entries(configTransformResult.errorsByConfigName).forEach(
+      ([configName, errors]) => {
+        console.log(`- ${configName}:`);
+        errors.forEach((error) => {
+          console.log(`  - ${transformErrorToString(error)}`);
+        });
+      },
+    );
+    console.log('');
+    const proceed = await getYesNo(
+      'Proceed to import the flags that can be imported?',
+    );
+    if (!proceed) {
+      process.exit(0);
+    }
+
+    const validConfigGateNames = configTransformResult.validConfigs.map(
+      (config) => config.gate.name,
+    );
+    if (
+      await needToDeleteExistingImportedGates(validConfigGateNames, statsigArgs)
+    ) {
+      const proceed = await getYesNo(
+        'There are existing imported gates. Proceed to delete them?',
+      );
+      if (!proceed) {
+        process.exit(0);
+      }
+      const deleteExistingImportedGatesResult =
+        await deleteExistingImportedGates(
+          validConfigGateNames,
+          LAUNCHDARKLY_IMPORT_TAG,
+          statsigArgs,
+        );
+      if (!deleteExistingImportedGatesResult.ok) {
+        console.log(
+          `Existing imported gates without being tagged with "${LAUNCHDARKLY_IMPORT_TAG}": ${deleteExistingImportedGatesResult.existingGatesWithoutImportTag.join(', ')}.`,
+        );
+        console.log(
+          `Someone may have created those gates manually in Statsig. You can fix this by either tagging those gates with "${LAUNCHDARKLY_IMPORT_TAG}" or deleting them manually.`,
+        );
+        process.exit(1);
+      }
+    }
+
+    await importConfigs(
+      configTransformResult.validConfigs,
+      LAUNCHDARKLY_IMPORT_TAG,
+      LAUNCHDARKLY_IMPORT_TAG_DESCRIPTION,
+      statsigArgs,
+    );
+    console.log(
+      `Imported ${configTransformResult.validConfigs.length} flags to Statsig.`,
+    );
+  } else {
+    console.error(
+      `Invalid --from value. Available values: ${Object.values(MigrateFrom).join(', ')}`,
+    );
+    process.exit(1);
+  }
+}
+
+async function getYesNo(question: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    rl.question(`${question} (y/n) `, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === 'y');
+    });
+  });
+}
+
+main();

--- a/src/launchdarkly.ts
+++ b/src/launchdarkly.ts
@@ -1,0 +1,777 @@
+import type {
+  ConfigTransformResult,
+  StatsigCondition,
+  StatsigConditionType,
+  StatsigConfig,
+  StatsigEnvironment,
+  StatsigOperatorType,
+  StatsigOverride,
+  StatsigRule,
+  TransformError,
+  TransformResult,
+} from './types';
+
+import { capRuleName } from './util';
+import nullthrows from 'nullthrows';
+
+const BASE_URL = 'https://app.launchdarkly.com/api/v2';
+const API_VERSION = '20240415';
+
+type Args = {
+  apiKey: string;
+  projectID: string;
+  // Context Kinds are a LaunchDarkly concept that needs to map to Statsig. The
+  // user needs to provide the mapping.
+  contextKindToUnitIDMapping: Record<string, string>;
+  contextCustomAttributeMapping?: Record<string, Record<string, string>>;
+  environmentNameMapping: Record<string, string>;
+  throttle: <T>(fn: () => Promise<T>) => () => Promise<T>;
+};
+
+function getRequestOptions({ apiKey }: { apiKey: string }): RequestInit {
+  return {
+    headers: {
+      Authorization: apiKey,
+      'LD-API-Version': API_VERSION,
+    },
+  };
+}
+
+export const launchdarklyApiThrottle = {
+  limit: 10,
+  interval: 500, //ms
+};
+
+export async function getLaunchDarklyConfigs(
+  args: Args,
+): Promise<ConfigTransformResult> {
+  const flagKeysResult = await listFeatureFlagKeys(args);
+  if (!flagKeysResult.transformed) {
+    return {
+      totalConfigCount: undefined,
+      validConfigs: [],
+      errorsByConfigName: { '': flagKeysResult.errors },
+    };
+  }
+
+  const flags = await Promise.all(
+    flagKeysResult.result.map((flagKey) => getFeatureFlag(flagKey, args)),
+  );
+
+  const configTransformResult: ConfigTransformResult = {
+    totalConfigCount: flagKeysResult.result.length,
+    validConfigs: [],
+    errorsByConfigName: {},
+  };
+
+  flags.forEach((flag) => {
+    const transformResult = transformFlagToGate(flag as LaunchDarklyFlag, args);
+    if (transformResult.transformed) {
+      configTransformResult.validConfigs.push(transformResult.result);
+    } else {
+      transformResult.errors.forEach((error) => {
+        configTransformResult.errorsByConfigName[error.flagKey] =
+          configTransformResult.errorsByConfigName[error.flagKey] || [];
+        configTransformResult.errorsByConfigName[error.flagKey].push(error);
+      });
+    }
+  });
+  return configTransformResult;
+}
+
+async function listFeatureFlagKeys({
+  apiKey,
+  projectID,
+  throttle,
+}: Args): Promise<TransformResult<string[]>> {
+  const allFlagKeys: string[] = [];
+  let nextPage = `${BASE_URL}/flags/${projectID}?summary=0`;
+  do {
+    try {
+      const response = await throttle(() =>
+        fetch(
+          `${BASE_URL}/flags/${projectID}?summary=0`,
+          getRequestOptions({ apiKey }),
+        ),
+      )();
+      if (!response.ok) {
+        throw new Error(
+          `Failed to list LaunchDarkly flag: ${response.statusText} ${await response.text()}`,
+        );
+      }
+      const data = await response.json();
+      allFlagKeys.push(...data.items.map((item: { key: string }) => item.key));
+      nextPage = data._links?.next?.href;
+    } catch (error) {
+      return {
+        transformed: false,
+        errors: [
+          {
+            type: 'fetch_error',
+            message: error instanceof Error ? error.message : String(error),
+            flagKey: '',
+          },
+        ],
+      };
+    }
+  } while (nextPage);
+
+  return {
+    transformed: true,
+    result: allFlagKeys,
+  };
+}
+
+async function getFeatureFlag(
+  flagKey: string,
+  { apiKey, projectID, throttle }: Args,
+): Promise<Object> {
+  const response = await throttle(() =>
+    fetch(`${BASE_URL}/flags/${projectID}/${flagKey}`, {
+      headers: {
+        Authorization: `${apiKey}`,
+        'LD-API-Version': API_VERSION,
+      },
+    }),
+  )();
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch LaunchDarkly flag: ${response.statusText} ${await response.text()}`,
+    );
+  }
+  return response.json();
+}
+
+type LaunchDarklyFlag = {
+  kind: string;
+  key: string;
+  name: string;
+  description: string;
+  temporary: boolean;
+  tags: string[];
+  environments?: Record<
+    string,
+    {
+      on: boolean;
+      archived: boolean;
+      targets?: {
+        values: string[];
+        variation: number;
+        contextKind?: string;
+      }[];
+      contextTargets?: {
+        values: string[];
+        variation: number;
+        contextKind?: string;
+      }[];
+      offVariation?: number;
+      rules?: {
+        description?: string;
+        clauses: {
+          attribute: string;
+          contextKind?: string;
+          op: string;
+          values: unknown[];
+          negate: boolean;
+        }[];
+        variation?: number;
+        rollout?: {
+          variations: {
+            variation: number;
+            weight: number;
+          }[];
+        };
+      }[];
+      fallthrough?: {
+        variation?: number;
+        rollout?: {
+          variations: {
+            variation: number;
+            weight: number;
+          }[];
+        };
+      };
+    }
+  >;
+};
+type LaunchDarklyFlagEnvironment = NonNullable<
+  LaunchDarklyFlag['environments']
+>[string];
+type LaunchDarklyFlagRule = NonNullable<
+  LaunchDarklyFlagEnvironment['rules']
+>[number];
+type LaunchDarklyFlagClause = NonNullable<
+  LaunchDarklyFlagRule['clauses']
+>[number];
+type LaunchDarklyFlagFallthrough = NonNullable<
+  LaunchDarklyFlagEnvironment['fallthrough']
+>;
+
+function transformFlagToGate(
+  flag: LaunchDarklyFlag,
+  args: Args,
+): TransformResult<StatsigConfig> {
+  if (flag.kind !== 'boolean') {
+    return {
+      transformed: false,
+      errors: [
+        {
+          type: 'unsupported_flag_kind',
+          flagKey: flag.key,
+          flagKind: flag.kind,
+        },
+      ],
+    };
+  }
+
+  const overrides: StatsigOverride[] = [];
+  const rules: StatsigRule[] = [];
+  const errors: TransformError[] = [];
+
+  Object.entries(flag.environments || {}).forEach(([env, environmentData]) => {
+    if (environmentData.targets && environmentData.targets.length > 0) {
+      // Build the override object
+      (environmentData.targets ?? [])
+        .concat(environmentData.contextTargets ?? [])
+        .forEach((overrideTarget) => {
+          const contextKind = overrideTarget.contextKind ?? 'user';
+          const unitID =
+            contextKind === 'user'
+              ? 'userID'
+              : args.contextKindToUnitIDMapping?.[contextKind];
+          if (!unitID) {
+            errors.push({
+              type: 'unit_id_not_mapped',
+              contextKind,
+              flagKey: flag.key,
+            });
+            return;
+          }
+
+          let environmentOverride = overrides.find((o) => o.unitID === unitID);
+          if (!environmentOverride) {
+            environmentOverride = {
+              environment: args.environmentNameMapping[env] ?? env,
+              unitID,
+              passingIDs: [],
+              failingIDs: [],
+            };
+            overrides.push(environmentOverride);
+          }
+
+          if (overrideTarget.variation == 0) {
+            environmentOverride.passingIDs.push(...overrideTarget.values);
+          } else if (overrideTarget.variation == 1) {
+            environmentOverride.failingIDs.push(...overrideTarget.values);
+          }
+        });
+    }
+
+    for (const [ruleIndex] of (environmentData.rules ?? []).entries()) {
+      const ruleResult = translateLaunchDarklyRule(
+        flag.key,
+        env,
+        environmentData,
+        ruleIndex,
+        args,
+      );
+      if (ruleResult.transformed) {
+        rules.push(ruleResult.result);
+      } else {
+        errors.push(...ruleResult.errors);
+      }
+    }
+
+    const fallthroughRule = transformFallthroughRule(
+      flag.key,
+      env,
+      environmentData,
+      args,
+    );
+    if (fallthroughRule.transformed) {
+      rules.push(fallthroughRule.result);
+    } else {
+      errors.push(...fallthroughRule.errors);
+    }
+  });
+
+  if (errors.length > 0) {
+    return {
+      transformed: false,
+      errors,
+    };
+  }
+
+  return {
+    transformed: true,
+    result: {
+      type: 'gate',
+      gate: {
+        id: flag.key,
+        name: flag.name,
+        description: flag.description,
+        type: flag.temporary ? 'TEMPORARY' : 'PERMANENT',
+        tags: flag.tags,
+        rules,
+      },
+      overrides,
+    },
+  };
+}
+
+// Translates a LaunchDarkly rule into one or more Statsig rules, accounting for complex segment matches.
+function translateLaunchDarklyRule(
+  flagKey: string,
+  environmentName: string,
+  flagEnvironment: LaunchDarklyFlagEnvironment,
+  ruleIndex: number,
+  args: Args,
+): TransformResult<StatsigRule> {
+  let passPercentage;
+  const rule = nullthrows(flagEnvironment.rules?.[ruleIndex]);
+  const errors: TransformError[] = [];
+
+  if (!flagEnvironment.on) {
+    // flag is off, display "offVariation"
+    passPercentage = flagEnvironment.offVariation === 0 ? 100 : 0;
+  } else {
+    // Translate the launch darkly pass percentage to statsig pass percentage
+    const passPercentageResult = transformRulePassPercentage(flagKey, rule);
+    if (!passPercentageResult.transformed) {
+      errors.push(...passPercentageResult.errors);
+    } else {
+      passPercentage = passPercentageResult.result;
+    }
+  }
+
+  // Translate each clause within the rule to a Statsig condition.
+  const conditions: StatsigCondition[] = [];
+  for (const clause of rule.clauses) {
+    const conditionResult = translateRuleClause(flagKey, clause, args);
+    if (conditionResult.transformed) {
+      conditions.push(conditionResult.result);
+    } else {
+      errors.push(...conditionResult.errors);
+    }
+  }
+
+  if (errors.length > 0) {
+    return {
+      transformed: false,
+      errors,
+    };
+  }
+
+  //sending rule index to avoind 'Duplicate rule name(s) given' error for many unnamed rules
+  const ruleName =
+    '(' +
+    environmentName +
+    ') ' +
+    (rule.description
+      ? rule.description + ' import ' + (ruleIndex + 1)
+      : 'import ' + (ruleIndex + 1));
+
+  return {
+    transformed: true,
+    result: {
+      name: capRuleName(ruleName),
+      passPercentage: nullthrows(passPercentage),
+      conditions,
+      environments: [
+        args.environmentNameMapping[environmentName] ?? environmentName,
+      ],
+    },
+  };
+}
+
+function transformFallthroughRule(
+  flagKey: string,
+  environmentName: string,
+  flagEnvironment: LaunchDarklyFlagEnvironment,
+  args: Args,
+): TransformResult<StatsigRule> {
+  const ruleName = '(' + environmentName + ') Fall through imported rule';
+
+  const fallthroughRule: StatsigRule = {
+    name: capRuleName(ruleName),
+    passPercentage: 0,
+    conditions: [{ type: 'public' }],
+    environments: [
+      args.environmentNameMapping[environmentName] ?? environmentName,
+    ],
+  };
+
+  if (!flagEnvironment.on) {
+    fallthroughRule.passPercentage =
+      flagEnvironment.offVariation == 0 ? 100 : 0;
+  } else if (flagEnvironment.fallthrough) {
+    const passPercentageResult = transformRulePassPercentage(
+      flagKey,
+      flagEnvironment.fallthrough,
+    );
+    if (!passPercentageResult.transformed) {
+      return passPercentageResult;
+    } else {
+      fallthroughRule.passPercentage = passPercentageResult.result;
+    }
+  }
+
+  return {
+    transformed: true,
+    result: fallthroughRule,
+  };
+}
+
+function transformRulePassPercentage(
+  flagKey: string,
+  rule: LaunchDarklyFlagRule | LaunchDarklyFlagFallthrough,
+): TransformResult<number> {
+  if (rule.rollout) {
+    // For rollouts, find the weight of the enabled variation and convert to a percentage.
+    const variation = rule.rollout.variations[0];
+    return {
+      transformed: true,
+      result: variation.weight / 1000, // Assuming weights are out of 100,000 for a percentage based on testing
+    };
+  } else if (rule.variation === 0) {
+    return {
+      transformed: true,
+      result: 100,
+    };
+  } else if (rule.variation === 1) {
+    return {
+      transformed: true,
+      result: 0,
+    };
+  } else {
+    return {
+      transformed: false,
+      errors: [{ type: 'unsupported_pass_percentage', flagKey }],
+    };
+  }
+}
+
+function transformRuleClauseType(
+  flagKey: string,
+  clause: LaunchDarklyFlagClause,
+  { contextKindToUnitIDMapping, contextCustomAttributeMapping }: Args,
+): TransformResult<Pick<StatsigCondition, 'type' | 'field' | 'customID'>> {
+  const contextKind = clause.contextKind ?? 'user';
+  if (clause.attribute === 'key') {
+    if (contextKind === 'user') {
+      return {
+        transformed: true,
+        result: { type: 'user_id' },
+      };
+    }
+    const unitID = contextKindToUnitIDMapping?.[contextKind];
+    if (!unitID) {
+      return {
+        transformed: false,
+        errors: [
+          {
+            type: 'unit_id_not_mapped',
+            contextKind,
+            flagKey,
+          },
+        ],
+      };
+    }
+    return {
+      transformed: true,
+      result: {
+        type: 'unit_id',
+        customID: unitID,
+      },
+    };
+  }
+
+  const typeMapping: Record<string, StatsigConditionType> = {
+    country: 'country',
+    email: 'email',
+    ip: 'ip_address',
+  };
+  if (typeMapping[clause.attribute]) {
+    return {
+      transformed: true,
+      result: {
+        type: typeMapping[clause.attribute],
+      },
+    };
+  }
+
+  const customField =
+    contextCustomAttributeMapping?.[contextKind]?.[clause.attribute];
+  if (!customField) {
+    return {
+      transformed: false,
+      errors: [
+        {
+          type: 'custom_attribute_not_mapped',
+          contextKind,
+          attribute: clause.attribute,
+          flagKey,
+        },
+      ],
+    };
+  }
+
+  return {
+    transformed: true,
+    result: { type: 'custom_field', field: customField },
+  };
+}
+
+function transformRuleOperator(
+  flagKey: string,
+  operator: string,
+  negate: boolean,
+): TransformResult<StatsigOperatorType> {
+  const mapping: Record<string, StatsigOperatorType> = {
+    lessThan: negate ? 'gte' : 'lt',
+    lessThanOrEqual: 'lte',
+    greaterThan: negate ? 'lte' : 'gt',
+    greaterThanOrEqual: 'gte',
+    before: 'before',
+    after: 'after',
+    in: negate ? 'none' : 'any',
+    matches: negate ? 'none' : 'str_matches',
+    contains: negate ? 'str_contains_none' : 'str_contains_any',
+    semVerEqual: 'version_eq',
+    startsWith: 'str_matches',
+    endsWith: 'str_matches',
+  };
+
+  // Logic to throw an error if the operator is not supported
+  const statsigOperator = mapping[operator];
+  if (statsigOperator) {
+    return {
+      transformed: true,
+      result: statsigOperator,
+    };
+  } else {
+    return {
+      transformed: false,
+      errors: [{ type: 'unsupported_operator', operator, flagKey }],
+    };
+  }
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isArrayOfPrimitives(
+  values: unknown[],
+): values is string[] | number[] | boolean[] {
+  return (
+    values.every((v) => typeof v === 'string') ||
+    values.every((v) => typeof v === 'number') ||
+    values.every((v) => typeof v === 'boolean')
+  );
+}
+
+function transformClauseValuesForOperator(
+  flagKey: string,
+  operator: string,
+  values: unknown[],
+): TransformResult<StatsigCondition['targetValue']> {
+  if (!isArrayOfPrimitives(values)) {
+    return {
+      transformed: false,
+      errors: [{ type: 'invalid_clause_values', flagKey, operator, values }],
+    };
+  }
+  switch (operator) {
+    case 'startsWith':
+      return {
+        transformed: true,
+        result: values.map((v) => `^${escapeRegex(v.toString())}`),
+      };
+    case 'endsWith':
+      return {
+        transformed: true,
+        result: values.map((v) => `${escapeRegex(v.toString())}$`),
+      };
+    default:
+      //LD allows you to run in clause against array of booleans
+      //Statsig doesn't, must coerce to string
+      return {
+        transformed: true,
+        result: values.map((value) =>
+          typeof value != 'string' && typeof value != 'number'
+            ? JSON.stringify(value)
+            : value,
+        ) as string[] | number[],
+      };
+  }
+}
+
+function translateRuleClause(
+  flagKey: string,
+  clause: LaunchDarklyFlagClause,
+  args: Args,
+): TransformResult<StatsigCondition> {
+  const clauseTypeResult = transformRuleClauseType(flagKey, clause, args);
+  const operatorResult = transformRuleOperator(
+    flagKey,
+    clause.op,
+    clause.negate,
+  );
+  const valuesResult = transformClauseValuesForOperator(
+    flagKey,
+    clause.op,
+    clause.values,
+  );
+  if (
+    !clauseTypeResult.transformed ||
+    !operatorResult.transformed ||
+    !valuesResult.transformed
+  ) {
+    const errors = [];
+    if (!clauseTypeResult.transformed) {
+      errors.push(...clauseTypeResult.errors);
+    }
+    if (!operatorResult.transformed) {
+      errors.push(...operatorResult.errors);
+    }
+    if (!valuesResult.transformed) {
+      errors.push(...valuesResult.errors);
+    }
+    return {
+      transformed: false,
+      errors,
+    };
+  }
+  const { type, field, customID } = clauseTypeResult.result;
+  const operator = operatorResult.result;
+  const targetValue = valuesResult.result;
+
+  const ruleCondition: StatsigCondition = {
+    type,
+    field,
+    customID,
+    operator,
+    targetValue,
+  };
+
+  return {
+    transformed: true,
+    result: ruleCondition,
+  };
+}
+
+export async function listLaunchDarklyEnvironments({
+  apiKey,
+  projectID,
+  throttle,
+}: Args): Promise<StatsigEnvironment[]> {
+  const response = await throttle(() =>
+    fetch(`${BASE_URL}/projects/${projectID}/environments`, {
+      headers: {
+        Authorization: `${apiKey}`,
+        'LD-API-Version': API_VERSION,
+      },
+    }),
+  )();
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list LaunchDarkly environments: ${response.statusText} ${await response.text()}`,
+    );
+  }
+  const data = await response.json();
+  return data.items.map(
+    (item: {
+      key: string;
+      critical: boolean;
+      approvalSettings?: { required: boolean };
+    }) => ({
+      name: item.key,
+      isProduction: item.critical,
+      requiresReview: item.approvalSettings?.required ?? false,
+    }),
+  );
+}
+
+export async function listLaunchDarklyContextKinds({
+  apiKey,
+  projectID,
+  throttle,
+}: Args): Promise<string[]> {
+  const response = await throttle(() =>
+    fetch(
+      `${BASE_URL}/projects/${projectID}/context-kinds`,
+      getRequestOptions({ apiKey }),
+    ),
+  )();
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list LaunchDarkly context kinds: ${response.statusText} ${await response.text()}`,
+    );
+  }
+  const data = await response.json();
+  return data.items.map(
+    (item: { key: string; description: string }) => item.key,
+  );
+}
+
+export async function ensureLaunchDarklySetup(
+  statsigEnvironments: StatsigEnvironment[],
+  statsigUnitIDs: string[],
+  args: Args,
+): Promise<
+  | { ok: true }
+  | {
+      ok: false;
+      unmappedEnvironments: string[];
+      invalidUnitIDs: string[];
+      contextKindsWithoutUnitIDs: string[];
+    }
+> {
+  const launchdarklyEnvironments = await listLaunchDarklyEnvironments(args);
+  const unmappedEnvironments = launchdarklyEnvironments.filter(
+    (environment) =>
+      !statsigEnvironments.some(
+        (statsigEnvironment) => statsigEnvironment.name === environment.name,
+      ) && !args.environmentNameMapping[environment.name],
+  );
+
+  const launchdarklyContextKinds = await listLaunchDarklyContextKinds(args);
+
+  const contextKindsAndUnitIDs = launchdarklyContextKinds.map((contextKind) => {
+    let unitID;
+    if (contextKind === 'user') {
+      unitID = 'user_id';
+    } else {
+      unitID = args.contextKindToUnitIDMapping[contextKind];
+    }
+    return [contextKind, unitID] as const;
+  });
+
+  const invalidUnitIDs = contextKindsAndUnitIDs
+    .map(([_, unitID]) => unitID)
+    .filter(
+      (unitID) =>
+        unitID && unitID !== 'user_id' && !statsigUnitIDs.includes(unitID),
+    );
+
+  const contextKindsWithoutUnitIDs = contextKindsAndUnitIDs.filter(
+    ([_, unitID]) => !unitID,
+  );
+
+  if (
+    unmappedEnvironments.length > 0 ||
+    invalidUnitIDs.length > 0 ||
+    contextKindsWithoutUnitIDs.length > 0
+  ) {
+    return {
+      ok: false,
+      unmappedEnvironments: unmappedEnvironments.map((e) => e.name),
+      invalidUnitIDs,
+      contextKindsWithoutUnitIDs: contextKindsWithoutUnitIDs.map(
+        ([contextKind]) => contextKind,
+      ),
+    };
+  }
+  return { ok: true };
+}

--- a/src/statsig.ts
+++ b/src/statsig.ts
@@ -1,0 +1,157 @@
+import type { StatsigEnvironment, StatsigGate } from './types';
+
+const BASE_URL = 'https://statsigapi.net/console/v1';
+const API_VERSION = '20240601';
+
+export const statsigApiThrottle = {
+  limit: 10,
+  interval: 500, //ms
+};
+
+export type Args = {
+  apiKey: string;
+  throttle: <T>(fn: () => Promise<T>) => () => Promise<T>;
+};
+
+function getRequestOptions(args: Args): RequestInit {
+  return {
+    headers: {
+      'Content-Type': 'application/json',
+      'STATSIG-API-KEY': args.apiKey,
+      'STATSIG-API-VERSION': API_VERSION,
+    },
+  };
+}
+
+export async function listStatsigEnvironments(
+  args: Args,
+): Promise<StatsigEnvironment[]> {
+  const response = await args.throttle(() =>
+    fetch(`${BASE_URL}/environments`, getRequestOptions(args)),
+  )();
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list Statsig environments: ${response.statusText} ${await response.text()}`,
+    );
+  }
+  const data = await response.json();
+  return data.data.environments;
+}
+
+export async function listStatsigUnitIDs(args: Args): Promise<string[]> {
+  const response = await args.throttle(() =>
+    fetch(`${BASE_URL}/unit_id_types`, getRequestOptions(args)),
+  )();
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list Statsig unit IDs: ${response.statusText} ${await response.text()}`,
+    );
+  }
+  const data = await response.json();
+  return data.data.map((item: { name: string }) => item.name);
+}
+
+export async function getStatsigGate(
+  gateName: string,
+  args: Args,
+): Promise<StatsigGate | null> {
+  const response = await args.throttle(() =>
+    fetch(`${BASE_URL}/gates/${gateName}`, {
+      ...getRequestOptions(args),
+    }),
+  )();
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null;
+    }
+    throw new Error(
+      `Failed to get Statsig gate: ${response.statusText} ${await response.text()}`,
+    );
+  }
+  const data = await response.json();
+  return data.data;
+}
+
+export async function createStatsigGate(
+  gate: StatsigGate,
+  args: Args,
+): Promise<StatsigGate> {
+  const response = await args.throttle(() =>
+    fetch(`${BASE_URL}/gates`, {
+      method: 'POST',
+      ...getRequestOptions(args),
+      body: JSON.stringify({
+        id: gate.id,
+        name: gate.name,
+        description: gate.description,
+        tags: gate.tags,
+        type: gate.type,
+        rules: gate.rules,
+      }),
+    }),
+  )();
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create Statsig gate: ${response.statusText} ${await response.text()}`,
+    );
+  }
+  const data = await response.json();
+  return data.data;
+}
+
+export async function deleteStatsigGate(
+  gateName: string,
+  args: Args,
+): Promise<void> {
+  const response = await args.throttle(() =>
+    fetch(`${BASE_URL}/gates/${gateName}`, {
+      method: 'DELETE',
+      ...getRequestOptions(args),
+    }),
+  )();
+  if (!response.ok) {
+    throw new Error(
+      `Failed to delete Statsig gate: ${response.statusText} ${await response.text()}`,
+    );
+  }
+}
+
+export async function getStatsigTag(
+  tagName: string,
+  args: Args,
+): Promise<string | null> {
+  const response = await args.throttle(() =>
+    fetch(`${BASE_URL}/tags/${tagName}`, {
+      ...getRequestOptions(args),
+    }),
+  )();
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null;
+    }
+    throw new Error(
+      `Failed to get Statsig tag: ${response.statusText} ${await response.text()}`,
+    );
+  }
+  const data = await response.json();
+  return data.data.name;
+}
+
+export async function createStatsigTag(
+  tagName: string,
+  description: string,
+  args: Args,
+): Promise<void> {
+  const response = await args.throttle(() =>
+    fetch(`${BASE_URL}/tags`, {
+      method: 'POST',
+      ...getRequestOptions(args),
+      body: JSON.stringify({ name: tagName, description }),
+    }),
+  )();
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create Statsig tag: ${response.statusText} ${await response.text()}`,
+    );
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,169 @@
+// Transformation
+
+export type ConfigTransformResult = {
+  totalConfigCount: number | undefined;
+  validConfigs: StatsigConfig[];
+  errorsByConfigName: Record<string, TransformError[]>;
+};
+
+export type TransformResult<T> =
+  | {
+      transformed: true;
+      result: T;
+    }
+  | {
+      transformed: false;
+      errors: TransformError[];
+    };
+
+export type TransformError = {
+  flagKey: string;
+} & (
+  | {
+      type: 'fetch_error';
+      message: string;
+    }
+  | {
+      type: 'unsupported_flag_kind';
+      flagKind: string;
+    }
+  | {
+      type: 'unit_id_not_mapped';
+      contextKind: string;
+    }
+  | {
+      type: 'custom_attribute_not_mapped';
+      contextKind: string;
+      attribute: string;
+    }
+  | {
+      type: 'unsupported_pass_percentage';
+    }
+  | {
+      type: 'unsupported_operator';
+      operator: string;
+    }
+  | {
+      type: 'invalid_clause_values';
+      operator: string;
+      values: unknown[];
+    }
+);
+
+export function transformErrorToString(error: TransformError): string {
+  switch (error.type) {
+    case 'fetch_error':
+      return `Error fetching flag: ${error.message}`;
+    case 'unsupported_flag_kind':
+      return `Unsupported flag kind: ${error.flagKind}`;
+    case 'unit_id_not_mapped':
+      return `Unit ID not mapped for context kind: ${error.contextKind}`;
+    case 'custom_attribute_not_mapped':
+      return `Custom attribute not mapped for context kind: ${error.contextKind}.${error.attribute}`;
+    case 'unsupported_pass_percentage':
+      return `Unsupported pass percentage`;
+    case 'unsupported_operator':
+      return `Unsupported operator: ${error.operator}`;
+    case 'invalid_clause_values':
+      return `Invalid clause values: ${error.operator} with values: ${error.values.join(', ')}`;
+    default:
+      const exhaustive: never = error;
+      return exhaustive;
+  }
+}
+
+// Statsig API Types
+
+export type StatsigEnvironment = {
+  name: string;
+  isProduction: boolean;
+  requiresReview: boolean;
+};
+
+export type StatsigConfig = {
+  type: 'gate';
+  gate: StatsigGate;
+  overrides: StatsigOverride[];
+};
+
+export type StatsigGate = {
+  id: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+  type?: 'PERMANENT' | 'TEMPORARY';
+  rules: StatsigRule[];
+};
+
+export type StatsigRule = {
+  name: string;
+  passPercentage: number;
+  conditions: StatsigCondition[];
+  environments?: string[];
+};
+
+export type StatsigCondition = {
+  type: StatsigConditionType;
+  customID?: string | null;
+  field?: string | null;
+  operator?: StatsigOperatorType;
+  targetValue?: number | string | number[] | string[];
+};
+
+export type StatsigConditionType =
+  | 'app_version'
+  | 'browser_name'
+  | 'browser_version'
+  | 'country'
+  | 'custom_field'
+  | 'email'
+  | 'environment_tier'
+  | 'fails_gate'
+  | 'fails_segment'
+  | 'ip_address'
+  | 'locale'
+  | 'os_name'
+  | 'os_version'
+  | 'passes_gate'
+  | 'passes_segment'
+  | 'public'
+  | 'time'
+  | 'unit_id'
+  | 'user_id'
+  | 'device_model'
+  | 'target_app';
+
+export type StatsigOperatorType =
+  | 'any'
+  | 'none'
+  | 'any_case_sensitive'
+  | 'none_case_sensitive'
+  | 'str_contains_any'
+  | 'str_contains_none'
+  | 'gt'
+  | 'lt'
+  | 'lte'
+  | 'gte'
+  | 'version_gt'
+  | 'version_lt'
+  | 'version_gte'
+  | 'version_lte'
+  | 'version_eq'
+  | 'after'
+  | 'before'
+  | 'on'
+  | 'is_null'
+  | 'is_not_null'
+  | 'str_matches'
+  | 'encoded_any'
+  | 'array_contains_any'
+  | 'array_contains_none'
+  | 'array_contains_all'
+  | 'not_array_contains_all';
+
+export type StatsigOverride = {
+  environment: string | null;
+  unitID: string;
+  passingIDs: string[];
+  failingIDs: string[];
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,5 @@
+const MAX_RULE_NAME_LENGTH = 100;
+
+export function capRuleName(ruleName: string): string {
+  return ruleName.substring(0, MAX_RULE_NAME_LENGTH);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "skipLibCheck": true,
+
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
This is pretty much a 1-to-1 port from https://github.com/statsig-io/launchDarkly_migration_script_template/ but now it's:

1. Internally type safe
2. Has types matching Statsig's console API
3. Has types matching LaunchDarkly's API
4. Has IO split out from the core functionality, so the functionality can be embedded in console.

This repo is intended to be public.

Tested by loading some flags from LD to Statsig.