### PR TITLE
[bugfix] check for existing configs by id not display name

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -190,10 +190,10 @@ export default async function cli(): Promise<void> {
 
     const validConfigNames = configTransformResult.validConfigs.map((config) =>
       config.type === 'gate'
-        ? config.gate.name
+        ? config.gate.id
         : config.type === 'dynamic_config'
-          ? config.dynamicConfig.name
-          : config.segment.name,
+          ? config.dynamicConfig.id
+          : config.segment.id,
     );
     if (
       await needToDeleteExistingImportedConfigs(validConfigNames, statsigArgs)


### PR DESCRIPTION
# Summary

Whenever the script is run, if there exists Statsig configs that has the same id with LD flags, we want to delete these Statsig configs first before migrating the LD flags.

The bug: We mixed up configs name and id. We should search by id, not config name.

# Test

Run the script once to have some (or all) LD flags on Statsig.

![image.png](https://app.graphite.dev/user-attachments/assets/7a5130a5-b0e3-4dbc-af86-00d8c21acbec.png)

Run the script one more time. See that the script asks `There are existing imported gates, dynamic configs, or segments. Proceed to delete them? (y/n)`. On yes, see that the script proceeds without error and the LD flags are on Statsig as expected. On no, see the script terminates.

![image.png](https://app.graphite.dev/user-attachments/assets/97950409-0067-4544-aa1e-9663e531254c.png)



