### PR TITLE
import prerequisite targeting criteria

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,15 @@ export type TransformError = {
   | {
       type: 'segment_has_exclusions';
     }
+  | {
+      type: 'unsupported_prerequisite_flag_type';
+      prerequisiteFlagKind: string;
+      prerequisiteFlagKey: string;
+    }
+  | {
+      type: 'prerequisite_flag_does_not_exist';
+      prerequisiteFlagKey: string;
+    }
 );
 
 // Statsig API Types

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,6 +26,10 @@ export function transformErrorToString(error: TransformError): string {
       return `Unsupported segment type: ${error.flagKey}`;
     case 'segment_has_exclusions':
       return `Segment has exclusions: ${error.flagKey}`;
+    case 'prerequisite_flag_does_not_exist':
+      return `Prerequisite flag ${error.prerequisiteFlagKey} does not exist`;
+    case 'unsupported_prerequisite_flag_type':
+      return `Unsupported prerequisite flag type: ${error.prerequisiteFlagKey} is of type ${error.prerequisiteFlagKind}`;
     default:
       const exhaustive: never = error;
       return exhaustive;


### PR DESCRIPTION
# Summary

In LD, a gate can serve as a prerequisite to enable another gate. The prereq spec in LD is: "If `flagName` is ON and the context receives variation `A`, enable this flag. Otherwise, serve the off variation." To translate this into Statsig,

- If `flagName` is OFF, we set the first rule as `Everyone` gets the off variation.
- If `flagName` is ON, if variation `A` is true, map it to `fails_gate` `flagA`, and if variation `A` is false, map to `passes_gate` `flagA`.

# Test

in ld
- create `off boolean flag` as a boolean flag and turn it off.
- create `on boolean flag` as a boolean flag and turn it on.

### Case 1

`some ux change` flag, with off variation `new456` is prereq by `off boolean flag`. when migrated into statsig, 

![image.png](https://app.graphite.dev/user-attachments/assets/539ce7a6-b293-4f75-81e9-d8756b6bebd7.png)

expect

![image.png](https://app.graphite.dev/user-attachments/assets/2116fe59-18d0-40ce-a68b-d4962e51855c.png)

### Case 2

`new onboarding flow` flag, with off variation `test`, is prereq by `on boolean flag`, and context receiving is true

![image.png](https://app.graphite.dev/user-attachments/assets/b242ae7f-fed7-4532-849e-31a67a032fc1.png)

when migrated into statsig, expect

![image.png](https://app.graphite.dev/user-attachments/assets/c54d2ab0-12ae-4f17-a4b2-9ae0f52e01fd.png)

### Case 3 
`yet another ux change` flag, with off variation `padding`, is prereq by `on boolean flag`, and context receiving is false

![image.png](https://app.graphite.dev/user-attachments/assets/874932e2-b8bf-4fdc-a772-589e350cd76d.png)

when migrated into statsig, expect

![image.png](https://app.graphite.dev/user-attachments/assets/fa76fd13-2072-4386-be27-c6f933c71cda.png)

### Case 4

`depends on onboarding flow` prereq by `new onboarding flow`, which is NOT a boolean flag:

![image.png](https://app.graphite.dev/user-attachments/assets/e8dbd642-e507-4cd8-9f24-ce43dc641be6.png)

expect the script to say it cannot be migrated into statsig:

![image.png](https://app.graphite.dev/user-attachments/assets/bfa5e004-19d6-4f3e-b8bc-35be86dfb727.png)

