### PR TITLE
when run into error importing a flag skip that flag and continue with other flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -223,15 +223,42 @@ export default async function cli(): Promise<void> {
       }
     }
 
-    await importConfigs(
+    console.log('');
+
+    const importConfigsResult = await importConfigs(
       configTransformResult.validConfigs,
       LAUNCHDARKLY_IMPORT_TAG,
       LAUNCHDARKLY_IMPORT_TAG_DESCRIPTION,
       statsigArgs,
     );
     console.log(
-      `Imported ${configTransformResult.validConfigs.length} flags/segments to Statsig.`,
+      `Imported ${importConfigsResult.totalConfigImported} flags/segments to Statsig.`,
     );
+
+    console.log('');
+
+    if (Object.keys(importConfigsResult.noticesByConfigName).length > 0) {
+      console.log('Notices:');
+      Object.entries(importConfigsResult.noticesByConfigName).forEach(
+        ([configName, notice]) => {
+          console.log(`- ${configName}:`);
+          console.log(`  - ${notice}`);
+        },
+      );
+      console.log('');
+    }
+
+    if (Object.keys(importConfigsResult.errorsByConfigName).length > 0) {
+      console.log(
+        `\n${Object.keys(importConfigsResult.errorsByConfigName).length} flags/segments cannot be imported:`,
+      );
+      Object.entries(importConfigsResult.errorsByConfigName).forEach(
+        ([configName, error]) => {
+          console.log(`- ${configName}:`);
+          console.log(`  - ${error}`);
+        },
+      );
+    }
   } else {
     console.error(
       `Invalid --from value. Available values: ${Object.values(MigrateFrom).join(', ')}`,

--- a/src/launchdarkly.ts
+++ b/src/launchdarkly.ts
@@ -2,7 +2,7 @@ import type {
   ConfigTransformResult,
   StatsigCondition,
   StatsigConditionType,
-  StatsigConfig,
+  StatsigConfigWrapper,
   StatsigDynamicConfigRule,
   StatsigEnvironment,
   StatsigOperatorType,
@@ -443,7 +443,7 @@ type LaunchDarklyFlagFallthrough = NonNullable<
 function transformFlagToConfig(
   flag: LaunchDarklyFlag,
   args: Args,
-): TransformResult<StatsigConfig> {
+): TransformResult<StatsigConfigWrapper> {
   if (flag.kind === 'boolean') {
     return transformFlagToGate(flag, args);
   } else if (flag.kind === 'multivariate') {
@@ -465,7 +465,7 @@ function transformFlagToConfig(
 function transformFlagToGate(
   flag: LaunchDarklyFlag,
   args: Args,
-): TransformResult<StatsigConfig> {
+): TransformResult<StatsigConfigWrapper> {
   const overrides: StatsigOverride[] = [];
   const rules: StatsigRule[] = [];
   const errors: TransformError[] = [];
@@ -582,7 +582,7 @@ function transformFlagToGate(
 function transformFlagToDynamicConfig(
   flag: LaunchDarklyFlag,
   args: Args,
-): TransformResult<StatsigConfig> {
+): TransformResult<StatsigConfigWrapper> {
   const rules: StatsigDynamicConfigRule[] = [];
   const errors: TransformError[] = [];
 

--- a/src/statsig.ts
+++ b/src/statsig.ts
@@ -6,6 +6,8 @@ import type {
   StatsigSegment,
 } from './types';
 
+import { ImportResult } from './import';
+
 const BASE_URL = 'https://statsigapi.net/console/v1';
 const API_VERSION = '20240601';
 
@@ -81,7 +83,7 @@ export async function getStatsigGate(
 export async function createStatsigGate(
   gate: StatsigGate,
   args: Args,
-): Promise<StatsigGate> {
+): Promise<ImportResult<StatsigGate>> {
   const response = await args.throttle(() =>
     fetch(`${BASE_URL}/gates`, {
       method: 'POST',
@@ -97,12 +99,17 @@ export async function createStatsigGate(
     }),
   )();
   if (!response.ok) {
-    throw new Error(
-      `Failed to create Statsig gate: ${response.statusText} ${await response.text()}`,
-    );
+    return {
+      imported: false,
+      error: `Failed to create Statsig gate: ${response.statusText} ${await response.text()}`,
+    };
   }
+
   const data = await response.json();
-  return data.data;
+  return {
+    imported: true,
+    result: data.data,
+  };
 }
 
 export async function deleteStatsigGate(
@@ -126,7 +133,7 @@ export async function addStatsigGateOverrides(
   gateName: string,
   overrides: StatsigOverride[],
   args: Args,
-): Promise<void> {
+): Promise<ImportResult<void>> {
   const response = await args.throttle(() =>
     fetch(`${BASE_URL}/gates/${gateName}/overrides`, {
       method: 'POST',
@@ -137,10 +144,16 @@ export async function addStatsigGateOverrides(
     }),
   )();
   if (!response.ok) {
-    throw new Error(
-      `Failed to create Statsig gate overrides: ${response.statusText} ${await response.text()}`,
-    );
+    return {
+      imported: false,
+      error: `Failed to create Statsig gate overrides: ${response.statusText} ${await response.text()}`,
+    };
   }
+
+  return {
+    imported: true,
+    result: undefined,
+  };
 }
 
 export async function getStatsigDynamicConfig(
@@ -167,7 +180,7 @@ export async function getStatsigDynamicConfig(
 export async function createStatsigDynamicConfig(
   dynamicConfig: StatsigDynamicConfig,
   args: Args,
-): Promise<StatsigDynamicConfig> {
+): Promise<ImportResult<StatsigDynamicConfig>> {
   const response = await args.throttle(() =>
     fetch(`${BASE_URL}/dynamic_configs`, {
       method: 'POST',
@@ -182,12 +195,16 @@ export async function createStatsigDynamicConfig(
     }),
   )();
   if (!response.ok) {
-    throw new Error(
-      `Failed to create Statsig dynamic config: ${response.statusText} ${await response.text()}`,
-    );
+    return {
+      imported: false,
+      error: `Failed to create Statsig dynamic config: ${response.statusText} ${await response.text()}`,
+    };
   }
   const data = await response.json();
-  return data.data;
+  return {
+    imported: true,
+    result: data.data,
+  };
 }
 
 export async function deleteStatsigDynamicConfig(
@@ -231,7 +248,7 @@ export async function getStatsigSegment(
 export async function createStatsigSegment(
   segment: StatsigSegment,
   args: Args,
-): Promise<StatsigSegment> {
+): Promise<ImportResult<StatsigSegment>> {
   const response = await args.throttle(() =>
     fetch(`${BASE_URL}/segments`, {
       method: 'POST',
@@ -248,12 +265,16 @@ export async function createStatsigSegment(
     }),
   )();
   if (!response.ok) {
-    throw new Error(
-      `Failed to create Statsig segment: ${response.statusText} ${await response.text()}`,
-    );
+    return {
+      imported: false,
+      error: `Failed to create Statsig segment: ${response.statusText} ${await response.text()}`,
+    };
   }
   const data = await response.json();
-  return data.data;
+  return {
+    imported: true,
+    result: data.data,
+  };
 }
 
 export async function deleteStatsigSegment(

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type ConfigTransformResult = {
   totalConfigCount: number | undefined;
   totalFlagCount: number | undefined;
   totalSegmentCount: number | undefined;
-  validConfigs: StatsigConfig[];
+  validConfigs: StatsigConfigWrapper[];
   noticesByConfigName: Record<string, TransformNotice[]>;
   errorsByConfigName: Record<string, TransformError[]>;
 };
@@ -80,7 +80,7 @@ export type StatsigEnvironment = {
   requiresReview: boolean;
 };
 
-export type StatsigConfig =
+export type StatsigConfigWrapper =
   | {
       type: 'gate';
       gate: StatsigGate;
@@ -94,6 +94,8 @@ export type StatsigConfig =
       type: 'segment';
       segment: StatsigSegment;
     };
+
+export type StatsigConfig = StatsigGate | StatsigDynamicConfig | StatsigSegment;
 
 export type StatsigGate = {
   id: string;


### PR DESCRIPTION
# Summary

tsia

original ticket: https://www.notion.so/statsig/LD-Migration-Script-Improvements-246d27b5090d80b593cde1f16ebb17ea?source=copy_link#258d27b5090d8061bda6f89a6bce7b85

# Test

Modify an API call to statsig in a way that makes it throw error (mis-spell something in the url for example). expect the script to skip error flags instead of terminating

![image.png](https://app.graphite.dev/user-attachments/assets/d5ddb69a-e31e-4603-b390-7227480c04b0.png)

