### PR TITLE
not import flags where key collides with another existing key

### DIFF
--- a/src/import.ts
+++ b/src/import.ts
@@ -85,34 +85,24 @@ export async function deleteExistingImportedConfigs(
     const dynamicConfig = await getStatsigDynamicConfig(configName, args);
     const segment = await getStatsigSegment(configName, args);
     if (gate) {
-      existingGates.push(gate);
-      if (!gate.tags?.includes(importTag)) {
+      if (gate.tags?.includes(importTag)) {
+        existingGates.push(gate);
+      } else {
         existingGatesWithoutImportTag.push(configName);
       }
     } else if (dynamicConfig) {
-      existingDynamicConfigNames.push(configName);
-      if (!dynamicConfig.tags?.includes(importTag)) {
+      if (dynamicConfig.tags?.includes(importTag)) {
+        existingDynamicConfigNames.push(configName);
+      } else {
         existingDynamicConfigsWithoutImportTag.push(configName);
       }
     } else if (segment) {
-      existingSegments.push(segment);
-      if (!segment.tags?.includes(importTag)) {
+      if (segment.tags?.includes(importTag)) {
+        existingSegments.push(segment);
+      } else {
         existingSegmentsWithoutImportTag.push(configName);
       }
     }
-  }
-
-  if (
-    existingGatesWithoutImportTag.length > 0 ||
-    existingDynamicConfigsWithoutImportTag.length > 0 ||
-    existingSegmentsWithoutImportTag.length > 0
-  ) {
-    return {
-      ok: false,
-      existingGatesWithoutImportTag,
-      existingDynamicConfigsWithoutImportTag,
-      existingSegmentsWithoutImportTag,
-    };
   }
 
   for (const dynamicConfigName of existingDynamicConfigNames) {
@@ -129,6 +119,19 @@ export async function deleteExistingImportedConfigs(
     sortConfigsFromDependentToIndependent(existingSegments, 'segment');
   for (const segment of segmentsFromDependentToIndependent) {
     await deleteStatsigSegment(segment.id, args);
+  }
+
+  if (
+    existingGatesWithoutImportTag.length > 0 ||
+    existingDynamicConfigsWithoutImportTag.length > 0 ||
+    existingSegmentsWithoutImportTag.length > 0
+  ) {
+    return {
+      ok: false,
+      existingGatesWithoutImportTag,
+      existingDynamicConfigsWithoutImportTag,
+      existingSegmentsWithoutImportTag,
+    };
   }
 
   return { ok: true };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,9 @@
-import type { StatsigRule, TransformError, TransformNotice } from './types';
+import type {
+  StatsigConfigWrapper,
+  StatsigRule,
+  TransformError,
+  TransformNotice,
+} from './types';
 
 export const RETURN_VALUE_WRAP_ATTRIBUTE = 'value';
 
@@ -137,4 +142,12 @@ export function sortConfigsFromDependentToIndependent<
   }
 
   return result;
+}
+
+export function getConfigID(config: StatsigConfigWrapper): string {
+  return config.type === 'gate'
+    ? config.gate.id
+    : config.type === 'dynamic_config'
+      ? config.dynamicConfig.id
+      : config.segment.id;
 }


### PR DESCRIPTION
# status quo

- in general, if an LD flag has the same id with a statsig config, we override the statsig config if the config has "Imported from launchdarkly" tag. 
- however, if there exists a statsig config with the same id with an LD flag, but the statsig config doesn't have the "Imported from launchdarkly" tag, we terminates the entire process, i.e we don't import any flag, until the user fixes it.

# changes
if there exists a statsig config with the same id with an LD flag, but the statsig config doesn't have the "Imported from launchdarkly" tag, we skip that flag and continue with the rest.

# test
have an LD flag and statsig config with the same id `my-flag`. make sure the statsig config doesn't have the "imported from launchdarkly" tag. expect that flag to be skipped and the rest to be imported. expect the terminal to say the flag `my-flag` is skipped.

![image.png](https://app.graphite.dev/user-attachments/assets/ac0f6f2c-d107-4b72-898e-716d59026773.png)

