### PR TITLE
migrate context kind into statsig id type

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -165,10 +165,12 @@ export default async function cli(): Promise<void> {
           : config.type === 'dynamic_config'
             ? config.dynamicConfig.name
             : config.segment.name;
+
+      const configID = getConfigID(config);
       console.log(
         `- ${config.type === 'gate' ? `[gate] ${configName}` : config.type === 'dynamic_config' ? `[dynamic config] ${configName}` : `[segment] ${configName}`}`,
       );
-      const notices = configTransformResult.noticesByConfigName[configName];
+      const notices = configTransformResult.noticesByConfigName[configID];
       if (notices) {
         for (const notice of notices) {
           console.log(`  - ${transformNoticeToString(notice)}`);

--- a/src/statsig.ts
+++ b/src/statsig.ts
@@ -95,6 +95,7 @@ export async function createStatsigGate(
         tags: gate.tags,
         type: gate.type,
         rules: gate.rules,
+        idType: gate.idType,
       }),
     }),
   )();
@@ -191,6 +192,7 @@ export async function createStatsigDynamicConfig(
         description: dynamicConfig.description,
         tags: dynamicConfig.tags,
         rules: dynamicConfig.rules,
+        idType: dynamicConfig.idType,
       }),
     }),
   )();

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,9 +21,12 @@ export type TransformResult<T> =
     };
 
 export type TransformNotice = {
-  type: 'return_value_wrapped';
   flagKey: string;
-};
+} & (
+  | { type: 'unsupported_bucket_by' }
+  | { type: 'return_value_wrapped' }
+  | { type: 'inconsistent_context_kind' }
+);
 
 export type TransformError = {
   flagKey: string;
@@ -113,6 +116,7 @@ export type StatsigGate = {
   tags?: string[];
   type?: 'PERMANENT' | 'TEMPORARY';
   rules: StatsigRule[];
+  idType?: string;
 };
 
 export type StatsigDynamicConfig = {
@@ -121,6 +125,7 @@ export type StatsigDynamicConfig = {
   description?: string;
   tags?: string[];
   rules: StatsigDynamicConfigRule[];
+  idType?: string;
 };
 
 export type StatsigSegment = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,8 +45,12 @@ export function transformNoticeToString(notice: TransformNotice): string {
   switch (notice.type) {
     case 'return_value_wrapped':
       return `JSON value would be wrapped as { "${RETURN_VALUE_WRAP_ATTRIBUTE}": <value> } as Statsig does not support non-object JSON values`;
+    case 'unsupported_bucket_by':
+      return `Statsig does not support any randomization attribute other than key.`;
+    case 'inconsistent_context_kind':
+      return `Statsig does not support multiple randomization context kinds.`;
     default:
-      const exhaustive: never = notice.type;
+      const exhaustive: never = notice;
       return exhaustive;
   }
 }


### PR DESCRIPTION
# summary


# test
**case 1: no randomization context kind**

![image.png](https://app.graphite.dev/user-attachments/assets/c48ddfdc-c870-4fb8-9047-58cac59ec6f7.png)

expect id type on statsig to be User ID

![image.png](https://app.graphite.dev/user-attachments/assets/de354332-367e-48fd-926d-06ba29520416.png)

**case 2: all randomization context kind are the same across the rules**

[ ] create a new context kind on LD `organization`. 
[ ] create new id type in Statsig `organizationID`. 
[ ] specify the mapping when running the script `--context-kind-to-unit-id organization=organizationID` 
[ ] for all rules that have randomization, set context kind to `organization`. have a few rules that don't have randomization.
[ ] run the script

![Screenshot 2025-09-12 at 1.48.31 PM.png](https://app.graphite.dev/user-attachments/assets/48e2e6e7-1a9f-49ee-a426-21358cd91f41.png)

expect id type of the gate/dc on statsig to be `organizationID`.

![image.png](https://app.graphite.dev/user-attachments/assets/7048530a-76fb-41fe-857b-ff6591eb6578.png)

[ ] in addition, set a few rules to have non-key attribute for randomization. 
[ ] run the script

![Screenshot 2025-09-12 at 1.50.42 PM.png](https://app.graphite.dev/user-attachments/assets/bf17bd76-7997-45c7-b270-80cfb4dd8ef1.png)

expect notices that say "Statsig does not support any randomization attribute other than key"

![image.png](https://app.graphite.dev/user-attachments/assets/7b22c683-1999-47d2-aa7d-74ee560cdbed.png)

**case 3: randomization context kinds are different between rules**

[ ] have one rule with randomization context `organization`
[ ] have one rule with randomization context `user`

![image.png](https://app.graphite.dev/user-attachments/assets/19fc5de1-9c0f-4432-802f-94d81d5410fe.png)

expect notices that say "Statsig does not support multiple randomization context kinds."

![image.png](https://app.graphite.dev/user-attachments/assets/3a56f4d7-0836-497d-bba1-175e57e05b35.png)

expect the id type of the gate/dc on statsig to be the first randomization context.

![image.png](https://app.graphite.dev/user-attachments/assets/dd558432-ebe5-4229-ae8e-ce9e36ffb691.png)

