### PR TITLE
put prereq rules before dc individual targeting rules

### DIFF
--- a/src/launchdarkly.ts
+++ b/src/launchdarkly.ts
@@ -494,6 +494,30 @@ function transformFlagToGate(
       return;
     }
 
+    const offVariationIndex = environmentData.offVariation;
+    if (offVariationIndex == null) {
+      return {
+        transformed: false,
+        errors: [{ type: 'unsupported_off_variation', flagKey: flag.key }],
+      };
+    }
+    const offVariation = flag.variations[offVariationIndex];
+
+    const preqRules = transformPrerequisitesRule({
+      offVariation,
+      flagKey: flag.key,
+      flagEnvironment: environmentData,
+      isFlagBoolean: true,
+      flagsByKey,
+      environmentName: env,
+      args,
+    });
+    if (preqRules.transformed) {
+      rules.push(...preqRules.result);
+    } else {
+      errors.push(...preqRules.errors);
+    }
+
     if (environmentData.targets && environmentData.targets.length > 0) {
       // Build the override object
       (environmentData.targets ?? [])
@@ -538,30 +562,6 @@ function transformFlagToGate(
             environmentOverride.failingIDs.push(...overrideTarget.values);
           }
         });
-    }
-
-    const offVariationIndex = environmentData.offVariation;
-    if (offVariationIndex == null) {
-      return {
-        transformed: false,
-        errors: [{ type: 'unsupported_off_variation', flagKey: flag.key }],
-      };
-    }
-    const offVariation = flag.variations[offVariationIndex];
-
-    const preqRules = transformPrerequisitesRule({
-      offVariation,
-      flagKey: flag.key,
-      flagEnvironment: environmentData,
-      isFlagBoolean: true,
-      flagsByKey,
-      environmentName: env,
-      args,
-    });
-    if (preqRules.transformed) {
-      rules.push(...preqRules.result);
-    } else {
-      errors.push(...preqRules.errors);
     }
 
     const percentageOverride = !environmentData.on
@@ -668,6 +668,31 @@ function transformFlagToDynamicConfig(
     if (args.onlyEnvironments != null && !args.onlyEnvironments.includes(env)) {
       return;
     }
+
+    const offVariationIndex = environmentData.offVariation;
+    if (offVariationIndex == null) {
+      return {
+        transformed: false,
+        errors: [{ type: 'unsupported_off_variation', flagKey: flag.key }],
+      };
+    }
+    const offVariation = variations[offVariationIndex];
+
+    const preqRules = transformPrerequisitesRule({
+      flagKey: flag.key,
+      offVariation,
+      flagEnvironment: environmentData,
+      isFlagBoolean: false,
+      flagsByKey,
+      environmentName: env,
+      args,
+    });
+    if (preqRules.transformed) {
+      rules.push(...preqRules.result);
+    } else {
+      errors.push(...preqRules.errors);
+    }
+
     if (environmentData.targets && environmentData.targets.length > 0) {
       // Dynamic config doesn't support overrides, so we need to create a rule for each target
       (environmentData.targets ?? [])
@@ -718,30 +743,6 @@ function transformFlagToDynamicConfig(
           };
           rules.push(rule);
         });
-    }
-
-    const offVariationIndex = environmentData.offVariation;
-    if (offVariationIndex == null) {
-      return {
-        transformed: false,
-        errors: [{ type: 'unsupported_off_variation', flagKey: flag.key }],
-      };
-    }
-    const offVariation = variations[offVariationIndex];
-
-    const preqRules = transformPrerequisitesRule({
-      flagKey: flag.key,
-      offVariation,
-      flagEnvironment: environmentData,
-      isFlagBoolean: false,
-      flagsByKey,
-      environmentName: env,
-      args,
-    });
-    if (preqRules.transformed) {
-      rules.push(...preqRules.result);
-    } else {
-      errors.push(...preqRules.errors);
     }
 
     for (const [ruleIndex] of (environmentData.rules ?? []).entries()) {


### PR DESCRIPTION
# summary
with the current code structure, dc individual targeting rules will precede the prerequisite rules from LD. this pr put the prereq rules first, then come the individual targeting rules.

# test

[ ] have a multivariate flag in LD with prereq and individual targeting rules
![image.png](https://app.graphite.dev/user-attachments/assets/e9c393eb-45ea-40e5-9dbb-1020d86fe624.png)

[ ] run the script

**Before**
expect the prereq rule comes **after** the individual targeting rule in statsig

**After**

expect the prereq rule comes **before** the individual targeting rule in statsig

![image.png](https://app.graphite.dev/user-attachments/assets/1fc7cd02-a0a5-4468-b1bc-5cdd2f6c0265.png)

