### PR TITLE
break ld rule with multiple segments into multiple statsig segment rules

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type TransformNotice = {
   | { type: 'unsupported_bucket_by' }
   | { type: 'return_value_wrapped' }
   | { type: 'inconsistent_context_kind' }
+  | { type: 'multiple_segments_condition'; ruleName: string }
 );
 
 export type TransformError = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -49,6 +49,8 @@ export function transformNoticeToString(notice: TransformNotice): string {
       return `Statsig does not support any randomization attribute other than key.`;
     case 'inconsistent_context_kind':
       return `Statsig does not support multiple randomization context kinds.`;
+    case 'multiple_segments_condition':
+      return `Statsig does not support multiple segments in a single condition. Please check flag "${notice.flagKey}" for conditions with multiple segments. We've only migrated the first segment in every condition.`;
     default:
       const exhaustive: never = notice;
       return exhaustive;


### PR DESCRIPTION
# summary

LD allows one rule to target multiple segments. Statsig doesn't allow that. This PR breaks every rule whose condition targets multiple segments into multiple rules.

Note: as an MVP, the change will only work on rules with:
1. One condition
2. The condition is either `passes_segments` or `fail_segments`
3. There are multiple target values in this condition.

For other rules that might have a condition that have multiple segments, only the first segment in that condition is migrated.

# test
In LD, create flag with a rule with multiple segments

![image.png](https://app.graphite.dev/user-attachments/assets/9a42924b-45a2-4a43-9189-cdc13bb46e30.png)

Run the script. In Statsig, expect the rule to be broken down into two rules:

![image.png](https://app.graphite.dev/user-attachments/assets/185d7083-0d43-4e27-832f-da4e01b67056.png)

If there's a rule with multiple conditions

![image.png](https://app.graphite.dev/user-attachments/assets/bfc1084e-3044-4bc1-a263-94c8ba2de7c7.png)

Only the first segment in each condition is migrated

![image.png](https://app.graphite.dev/user-attachments/assets/faff4d32-25aa-44f4-b38d-2d1618ed445d.png)

and there's a notice in the terminal output

![image.png](https://app.graphite.dev/user-attachments/assets/f60abaa6-8a5c-426f-a1f1-a1d9e6ccc54d.png)

