### PR TITLE
refactor importConfigs to return a list of imported result instead of summaries

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -330,33 +330,39 @@ export default async function cli(): Promise<void> {
       LAUNCHDARKLY_IMPORT_TAG_DESCRIPTION,
       statsigArgs,
     );
-    console.log(
-      `Imported ${importConfigsResult.totalConfigImported} flags/segments to Statsig.`,
+
+    const importedConfigs = importConfigsResult.filter(
+      (result) => result.imported,
     );
+    const notImportedConfigs = importConfigsResult.filter(
+      (result) => !result.imported,
+    );
+    const totalConfigImported = importedConfigs.length;
+    const totalConfigNotImported = notImportedConfigs.length;
 
-    console.log('');
+    console.log(`Imported ${totalConfigImported} flags/segments to Statsig.`);
 
-    if (Object.keys(importConfigsResult.noticesByConfigName).length > 0) {
-      console.log('Notices:');
-      Object.entries(importConfigsResult.noticesByConfigName).forEach(
-        ([configName, notice]) => {
-          console.log(`- ${configName}:`);
-          console.log(`  - ${notice}`);
-        },
-      );
+    importedConfigs.forEach((result) => {
+      const {
+        notice,
+        result: { config },
+      } = result;
+      if (notice) {
+        console.log(`- ${config.name}:`);
+        console.log(`  - ${notice}`);
+      }
+    });
+
+    if (totalConfigNotImported > 0) {
       console.log('');
-    }
-
-    if (Object.keys(importConfigsResult.errorsByConfigName).length > 0) {
       console.log(
-        `\n${Object.keys(importConfigsResult.errorsByConfigName).length} flags/segments cannot be imported:`,
+        `\n${totalConfigNotImported} flags/segments cannot be imported:`,
       );
-      Object.entries(importConfigsResult.errorsByConfigName).forEach(
-        ([configName, error]) => {
-          console.log(`- ${configName}:`);
-          console.log(`  - ${error}`);
-        },
-      );
+      notImportedConfigs.forEach((result) => {
+        const { error, configId } = result;
+        console.log(`- ${configId}:`);
+        console.log(`  - ${error}`);
+      });
     }
   } else {
     console.error(

--- a/src/statsig.ts
+++ b/src/statsig.ts
@@ -103,6 +103,7 @@ export async function createStatsigGate(
     return {
       imported: false,
       error: `Failed to create Statsig gate: ${response.statusText} ${await response.text()}`,
+      configId: gate.id,
     };
   }
 
@@ -148,6 +149,7 @@ export async function addStatsigGateOverrides(
     return {
       imported: false,
       error: `Failed to create Statsig gate overrides: ${response.statusText} ${await response.text()}`,
+      configId: gateName,
     };
   }
 
@@ -200,6 +202,7 @@ export async function createStatsigDynamicConfig(
     return {
       imported: false,
       error: `Failed to create Statsig dynamic config: ${response.statusText} ${await response.text()}`,
+      configId: dynamicConfig.id,
     };
   }
   const data = await response.json();
@@ -270,6 +273,7 @@ export async function createStatsigSegment(
     return {
       imported: false,
       error: `Failed to create Statsig segment: ${response.statusText} ${await response.text()}`,
+      configId: segment.id,
     };
   }
   const data = await response.json();


### PR DESCRIPTION
# Summary

`importConfigs` is returning a summary of the number of imported configs, along with notices and errors. Instead, we need the function to return every import result for every config, so that in the next PR, we can log each import result to a CSV file.

# Test
Run the script and see that the terminal remains the same.

![image.png](https://app.graphite.dev/user-attachments/assets/d33373b0-82ed-468d-a92f-d4f4ffa6b2e8.png)

