### PR TITLE
create custom field based on heuristic if no custom attribute mapping

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,11 @@ export type TransformNotice = {
   | { type: 'return_value_wrapped' }
   | { type: 'inconsistent_context_kind' }
   | { type: 'multiple_segments_condition'; ruleName: string }
+  | {
+      type: 'custom_attribute_not_mapped';
+      contextKind: string;
+      attribute: string;
+    }
 );
 
 export type TransformError = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -51,6 +51,8 @@ export function transformNoticeToString(notice: TransformNotice): string {
       return `Statsig does not support multiple randomization context kinds.`;
     case 'multiple_segments_condition':
       return `Statsig does not support multiple segments in a single condition. Please check flag "${notice.flagKey}" for conditions with multiple segments. We've only migrated the first segment in every condition.`;
+    case 'custom_attribute_not_mapped':
+      return `No explicit mapping for custom attribute "${notice.attribute}" of context kind "${notice.contextKind}", so we mapped it to "${notice.contextKind}.${notice.attribute}". Use --context-attribute-to-custom-field ${notice.contextKind}/${notice.attribute}=<custom-field-name> to specify a mapping.`;
     default:
       const exhaustive: never = notice;
       return exhaustive;


### PR DESCRIPTION
# Summary

If there's a custom attribute in LD that is not explicitly mapped to a custom field (i.e user didn't pass in a context attribute to custom field mapping for that custom attribute), we use heuristic to map it. 

E.g `organization` context kind, `location` custom attribute will be mapped to `organization.location`

# Test

I commented out the mapping between LD `user.ip` and Statsig `ip_address` so the script can treat `user.ip` as an unmapped custom attribute.

Have a rule in LD that uses `user.ip`

![image.png](https://app.graphite.dev/user-attachments/assets/d3f04a3d-84a1-4ef9-a01c-5d4cad8bdd3b.png)

Run the script.

Expect a notice in the terminal.

![image.png](https://app.graphite.dev/user-attachments/assets/0cf24032-097b-4d1a-ae13-423feb7bbb7e.png)

Expect custom field `user.ip` in Statsig

![image.png](https://app.graphite.dev/user-attachments/assets/1d29e200-ddd6-4925-9549-71d0e49a6b8d.png)

