### PR TITLE
[bugfix] use gate id not gate name to add gate overrides

### DIFF
--- a/src/import.ts
+++ b/src/import.ts
@@ -247,7 +247,7 @@ export async function importConfigs(
 
     if (importResult.imported && config.overrides.length > 0) {
       const overrideImportResult = await addStatsigGateOverrides(
-        gate.name,
+        gate.id,
         config.overrides,
         args,
       );


### PR DESCRIPTION
# Summary

The gate overrides CAPI endpoint requires `gate.id` to identify the gate, not `gate.name`. We've never been able to update overrides for gates until now.

# Test

Create a boolean flag in LD with individual targeting rules. 

![image.png](https://app.graphite.dev/user-attachments/assets/dec5bbdb-c74c-407f-9966-6dcf34d931d1.png)

Run the script. The flag should be successfully imported with the individual targeting rules converted into overrides

![image.png](https://app.graphite.dev/user-attachments/assets/3e9f51c9-080c-49d9-99f0-fe7a5987d03a.png)

