### PR TITLE
log company using script and errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.5",
       "license": "ISC",
       "dependencies": {
+        "@statsig/js-client": "^3.25.3",
         "csv-writer": "^1.6.0",
         "minimist": "^1.2.8",
         "nullthrows": "^1.1.1",
@@ -759,6 +760,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@statsig/client-core": {
+      "version": "3.25.3",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.25.3.tgz",
+      "integrity": "sha512-QmLigHO4aN9NHQLVvoP8bYFbuFFWaNJVm6RM59yQDAaW8AynMHjrmWtValpSD/sRjwEUUZBpQty0ciJCg56e9Q==",
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.25.3",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.25.3.tgz",
+      "integrity": "sha512-yySqWNONM/fHIUgTtF5QEYJqrnLaoBstPLCfJlCAbrTAzX+QnPYBzGcHBPlIFdRI4txP76RWCTnb9hRxyLZbsg==",
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.25.3"
       }
     },
     "node_modules/@types/minimist": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@statsig/js-client": "^3.25.3",
     "csv-writer": "^1.6.0",
     "minimist": "^1.2.8",
     "nullthrows": "^1.1.1",

--- a/src/statsig.ts
+++ b/src/statsig.ts
@@ -21,6 +21,14 @@ export type Args = {
   throttle: <T>(fn: () => Promise<T>) => () => Promise<T>;
 };
 
+export type StatsigCompany = {
+  companyID: string;
+  companyName: string;
+  isWarehouseNative: boolean;
+  orgID: string;
+  orgName: string;
+};
+
 function getRequestOptions(args: Args): RequestInit {
   return {
     headers: {
@@ -338,4 +346,22 @@ export async function createStatsigTag(
       `Failed to create Statsig tag: ${response.statusText} ${await response.text()}`,
     );
   }
+}
+
+export async function getStatsigCompany(
+  args: Args,
+): Promise<StatsigCompany | null> {
+  const response = await args.throttle(() =>
+    fetch(`${BASE_URL}/company`, {
+      ...getRequestOptions(args),
+    }),
+  )();
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to get Statsig company: ${response.statusText} ${await response.text()}`,
+    );
+  }
+  const data = await response.json();
+  return data.data;
 }

--- a/src/utils/statsig-sdk.ts
+++ b/src/utils/statsig-sdk.ts
@@ -1,0 +1,47 @@
+import { StatsigClient } from '@statsig/js-client';
+
+const STATSIG_CLIENT_KEY = 'client-SGEw7BPWvhK4x9vpcaJtkeoOvezcaQ0Lz7zKl57KQwJ';
+
+export default class StatsigLogger {
+  private statsig: StatsigClient;
+  private baseMetaData:
+    | Record<string, string | number | boolean | null>
+    | undefined;
+
+  constructor() {
+    this.statsig = new StatsigClient(
+      STATSIG_CLIENT_KEY,
+      {},
+      {
+        loggingEnabled: 'always',
+      },
+    );
+  }
+
+  addBaseMetaData(
+    metaData?: Record<string, string | number | boolean | null> | null,
+  ): void {
+    this.baseMetaData = { ...this.baseMetaData, ...metaData };
+  }
+
+  logEvent(
+    eventName: string,
+    value?: string | number,
+    eventMetadata?: Record<string, string | number | boolean | null> | null,
+  ): void {
+    this.statsig.logEvent(eventName, value, {
+      event_source: '@statsig/migrations',
+      ...this.baseMetaData,
+      ...eventMetadata,
+    });
+  }
+
+  logAndShutdown(
+    eventName: string,
+    value?: string | number,
+    eventMetadata?: Record<string, string | number | boolean | null> | null,
+  ): void {
+    this.logEvent(eventName, value, eventMetadata);
+    this.statsig.shutdown();
+  }
+}


### PR DESCRIPTION
# Summary

- Set up logging function
- Log the company using the script
- Log the errors the user encounter with the script

# Test

Run the script without passing all the required arguments. Check the Log Stream of the Statsig project. Expect to see `migration_script_error` events with value as the error message and metadata includes all the info about the company running the script.

Run the script again. When asked a yes/no question, answer anything but `y`. Check the Log Stream. Expect to see `migration_script_interrupt`.

To make the demo clearer, I locally swapped the client key with that of one of my projects:

[Screen Recording 2025-09-18 at 5.23.22 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/8c235c01-98aa-411c-a6db-a2c9d4e9f411.mov" />](https://app.graphite.dev/user-attachments/video/8c235c01-98aa-411c-a6db-a2c9d4e9f411.mov)

