### PR TITLE
[ez] tell users about the deletion of conflict statsig configs with tag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -336,7 +336,7 @@ export default async function cli(): Promise<void> {
       await needToDeleteExistingImportedConfigs(validConfigNames, statsigArgs)
     ) {
       const proceed = await getYesNo(
-        'Some LaunchDarkly flags you’re trying to import already exist in Statsig. Proceed to delete and re-import them?',
+        `We found some flags in Statsig with the same keys as LaunchDarkly flags. LaunchDarkly flags will overwrite Statsig flags tagged with ${LAUNCHDARKLY_IMPORT_TAG}. Flags without this tag will be skipped. Proceed?`,
       );
       if (!proceed) {
         statsigLogger.logAndShutdown(
@@ -361,13 +361,6 @@ export default async function cli(): Promise<void> {
             .concat(
               deleteExistingImportedConfigsResult.existingSegmentsWithoutImportTag,
             );
-        console.log('');
-        console.log(
-          `We avoid overriding Statsig configs that are not tagged with "${LAUNCHDARKLY_IMPORT_TAG}", so we cannot import these LaunchDarkly flags: ${untaggedConfigIds.join(', ')}.`,
-        );
-        console.log(
-          `Please tag the corresponding gates, dynamic configs, or segments in Statsig with "${LAUNCHDARKLY_IMPORT_TAG}" or delete them manually, after which you can re-run the script to migrate those flags.`,
-        );
 
         untaggedConfigIds.forEach((configID) => {
           const ldFlag = ldFlagsByKey.get(configID);


### PR DESCRIPTION
[Linear](https://linear.app/statsig/issue/FM-1007/tell-the-users-what-we-can-and-cannot-import-due-to-lack-of-tag-before)

**Before**:

![image.png](https://app.graphite.dev/user-attachments/assets/7e32ee7f-c659-425b-8835-4ba634f07562.png)

**After**:

![image.png](https://app.graphite.dev/user-attachments/assets/f28458ae-d49f-459d-9269-995af28ab1d8.png)

