### PR TITLE
[ez] update tag for configs migrated from LD

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ import pThrottle from 'p-throttle';
 import path from 'path';
 import readline from 'readline';
 
-const LAUNCHDARKLY_IMPORT_TAG = 'Imported from LaunchDarkly';
+const LAUNCHDARKLY_IMPORT_TAG = 'IMPORTED_FROM_LAUNCHDARKLY';
 const LAUNCHDARKLY_IMPORT_TAG_DESCRIPTION = 'Imported from LaunchDarkly';
 
 enum MigrateFrom {


### PR DESCRIPTION
[Linear](https://linear.app/statsig/issue/FM-1005/match-the-tag-in-console-and-ld-script)

Ensure that the tag for statsig configs migrated from LD is the same for both this migration script and the in console flow